### PR TITLE
Add New Zealand Dollar to currency options

### DIFF
--- a/ui/app/helpers/constants/available-conversions.json
+++ b/ui/app/helpers/constants/available-conversions.json
@@ -20,6 +20,10 @@
     "name": "Indian Rupee"
   },
   {
+    "code": "nzd",
+    "name": "New Zealand Dollar"
+  },
+  {
     "code": "php",
     "name": "Philippine Peso"
   },


### PR DESCRIPTION
Fixes: -

Explanation:  
I was annoyed that I wasn't able to view my wallet balance in my own currency. Had a quick dig through the code and found that it's a simple fix to include it. 
Double checked against the API that the currency is listed. 
If you are happy to accept this I can push the same change to the mobile repo as well. 

Manual testing steps:  
  - Navigate to Settings
  - Select Currency Conversion drop down
  - Select New Zealand Dollar from the drop down
  - Confirm wallet value is accurate